### PR TITLE
give check to Check.js

### DIFF
--- a/src/components/Options.js
+++ b/src/components/Options.js
@@ -40,6 +40,10 @@ export default function Options({ setPassword }) {
   const [symbols, setSymbols] = useState(false);
 
   const handleClick = () => {
+    if (!uppercase && !lowercase && !numbers && !symbols) {
+      setUppercase(true);
+      alert("at least on option must be true");
+    }
     let password = generatePassword(
       sliderValue,
       uppercase,


### PR DESCRIPTION
Now if someone unchecks all check buttons and clicks generate button, alert will ask them to check at least one option and uppercase letterin will be checked.

Need from this change comes from generate-password package itself. It must have at least one option checked.