### PR TITLE
edited CopyMessage's prop in Options.js

### DIFF
--- a/src/components/Display.js
+++ b/src/components/Display.js
@@ -26,7 +26,7 @@ export default function Display({ password }) {
   const [showMessage, setShowMessage] = useState(false);
   return (
     <Wrapper>
-      {showMessage && <CopyMessage message={password} />}
+      {showMessage && <CopyMessage text={password} />}
       <DisplayPassword>{password}</DisplayPassword>
       <CopyBtn
         text={password}


### PR DESCRIPTION
CopyMessage's prop message was changed to text, but not in Options.js. Because of this password wasn't displayed in copy message. This commit solves that problem.